### PR TITLE
Docker and go-env support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.github/
+vendor/
+.env
+Dockerfile
+docker-compose.yml

--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@ COMPOSE_PROJECT_NAME=cricscore-api
 DB_CONN="mongodb://backend-mongodb:27017"
 DB_NAME="cricscore_api_dev"
 HOST="localhost"
-PORT=8081
+PORT=8080

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 COMPOSE_PROJECT_NAME=cricscore-api
 DB_CONN="mongodb://backend-mongodb:27017"
 DB_NAME="cricscore_api_dev"
+HOST="localhost"
+PORT=8081

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+COMPOSE_PROJECT_NAME=cricscore-api
+DB_CONN="mongodb://backend-mongodb:27017"
+DB_NAME="cricscore_api_dev"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
+# Created by https://www.gitignore.io/api/go,linux,macos,windows,intellij+all,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=go,linux,macos,windows,intellij+all,visualstudiocode
+
+### Go ###
 # Binaries for programs and plugins
 *.exe
 *.exe~
 *.dll
 *.so
 *.dylib
+.env
 
 # Test binary, built with `go test -c`
 *.test
@@ -13,3 +18,175 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/go,linux,macos,windows,intellij+all,visualstudiocode

--- a/.realize.yaml
+++ b/.realize.yaml
@@ -1,0 +1,23 @@
+settings:
+  legacy:
+    force: false
+    interval: 0s
+schema:
+  - name: cricket-scoreboard-api
+    path: .
+    commands:
+      install:
+        status: true
+        method: go build -o app.out ./src
+      run:
+        status: true
+        method: ./app.out
+    watcher:
+      paths:
+        - /
+      extensions:
+        - go
+      ignored_paths:
+        - .git
+        - .realize
+        - vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:alpine
+
+RUN apk update && apk add git curl
+
+RUN go get github.com/oxequa/realize
+
+WORKDIR /opt/app
+
+COPY go.* /opt/app/
+
+RUN go mod download
+RUN go mod vendor
+
+COPY . .
+
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 This is an golang web api project for calculating cricket score.
 Go-gin is used as web wrapper and mongodb is used as database.
 More updates are comming.
+
+#### How to run
+- First run `docker-compose build` to build the image.
+- Run `docker-compose up` to start the app
+
+#### Note
+- App will restart if any file changed.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Go-gin is used as web wrapper and mongodb is used as database.
 More updates are comming.
 
 #### How to run
-- First run `docker-compose build` to build the image.
+- First copy `env` from `.env.example` by `cp .env.example .env`
+- Run `docker-compose build` to build the image.
 - Run `docker-compose up` to start the app
 
 #### Note

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+services:
+  scoreboard_api:
+    build: .
+    command: realize start --run
+    volumes:
+      - './src:/opt/app/src'
+    ports:
+      - '8080:8080'
+    depends_on:
+      - backend-mongodb
+  backend-mongodb:
+    image: mongo
+    restart: on-failure
+    volumes:
+      - 'database_vol:/data/db'
+    ports:
+      - '27017:27017'
+volumes:
+  database_vol: null

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,30 @@
+module cricket-scoreboard-api
+
+go 1.12
+
+require (
+	github.com/gin-contrib/cors v1.3.0
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/gin-gonic/gin v1.4.0
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/joho/godotenv v1.3.0
+	github.com/json-iterator/go v1.1.7 // indirect
+	github.com/mattn/go-isatty v0.0.9 // indirect
+	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/tidwall/pretty v1.0.0 // indirect
+	github.com/ugorji/go v1.1.7 // indirect
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
+	github.com/xdg/stringprep v1.0.0 // indirect
+	go.mongodb.org/mongo-driver v1.1.1
+	golang.org/x/crypto v0.0.0-20191002192127-34f69633bfdc
+	golang.org/x/net v0.0.0-20191003171128-d98b1b443823 // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sys v0.0.0-20191003212358-c178f38b412c // indirect
+	golang.org/x/text v0.3.2 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/square/go-jose.v2 v2.3.1
+	gopkg.in/yaml.v2 v2.2.4 // indirect
+)

--- a/src/main.go
+++ b/src/main.go
@@ -6,6 +6,12 @@ import (
 )
 
 func main() {
+	// Load environment variable from .env file
+	err := godotenv.Load()
+	if err != nil {
+		log.Printf("Error loading env file %v", err)
+	}
+
 	configuration := models.Configuration
 	router := startup.NewRouter()
 	router.Run(":" + configuration.Server.Port)

--- a/src/models/configuration.go
+++ b/src/models/configuration.go
@@ -1,9 +1,7 @@
 package models
 
 import (
-	"encoding/json"
 	"os"
-	"path/filepath"
 )
 
 var (
@@ -26,28 +24,11 @@ type Config struct {
 
 //New creates a new instance of Config
 func New(fileName string) Config {
-	file, err := os.Open(fileName)
-	if err != nil {
-		panic(err)
-	}
 
 	config := Config{}
-	decoder := json.NewDecoder(file)
-	err = decoder.Decode(&config)
-
-	if err != nil {
-		panic(err)
-	}
+	config.Db.EndPoint = os.Getenv("DB_CONN")
+	config.Server.Host = os.Getenv("HOST")
+	config.Server.Port = os.Getenv("PORT")
 
 	return config
-}
-
-//init sets up the initial states
-func init() {
-	dir, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
-
-	Configuration = New(filepath.Join(dir, "config", "app.config.json"))
 }


### PR DESCRIPTION
Added support for Docker for easy development and go-env to manage app configuration easily.
This project now adopted `go module` package manage. To learn more [Check This](https://medium.com/@adiach3nko/package-management-with-go-modules-the-pragmatic-guide-c831b4eaaf31).

Important Changes:
- `go.mod` [ go module package manage ]
- `src/main.go` [ initialization of go-env ]
- `src/models/configuration.go` [ replace json config with env variable ]
- `.realize.yaml` [ app auto restart config upon file change ]
- ` .env.example` [ example env for checking available variable ]

Important Note:
For now, docker only exposes port `8080` for running the application. Please do not change the port from `.env` but change it from `docker-compose.yml`. (This line need to be included in `README.md`).
